### PR TITLE
refactor: Fix mistakes with date

### DIFF
--- a/apps/web/src/data/resume.tsx
+++ b/apps/web/src/data/resume.tsx
@@ -87,7 +87,7 @@ export const DATA = {
       location: "San Francisco California, USA",
       title: "Backend Software Engineer",
       logoUrl: "/extend.png",
-      start: "January 2022",
+      start: "January 2023",
       end: "Present",
       description:
         "Collaborated on designing and implementing event-driven systems with AWS serverless technologies. Worked with engineering, product, and design teams to deliver platform enhancements and simplified customer integrations with third-party platforms. Encouraged innovation and continuous improvement. Developed robust APIs for leading commerce solutions and maintained automated tests to ensure product quality. Designed microservice-based systems and built event-driven architectures using AWS Lambda, DynamoDB, SQS, SNS, API Gateway, and other cloud services.",


### PR DESCRIPTION
# Description

Fix mistakes with date

This pull request includes a small change to the `apps/web/src/data/resume.tsx` file. The change updates the start date for a job position from "January 2022" to "January 2023".

* [`apps/web/src/data/resume.tsx`](diffhunk://#diff-ac51e7c08e5b89cedeaf55e82c4bd2f6898a671763f8c40c379e1d796fc26573L90-R90): Updated the `start` date for the "Backend Software Engineer" position from "January 2022" to "January 2023".

## Type of change

Please delete options that are not relevant.

- [x] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works